### PR TITLE
Adding GTM / GA4

### DIFF
--- a/_config-production.yml
+++ b/_config-production.yml
@@ -9,6 +9,6 @@ destination: www.open-cmsis-cdi.org
 # Production boolean used in layouts / includes
 production: true
 # Google Analytics
-# google_analytics:
-#   enabled: true
-#   code: G-HMVFZEVJSK
+google_analytics:
+  enabled: true
+  code: GTM-TZ6T2D2

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Open-CMSIS-CDI
 url: https://www.open-cmsis-cdi.org
 baseurl: ""
 description: |-
-   The Common Device Interface for IoT connected microcontrollers
+  The Common Device Interface for IoT connected microcontrollers
 destination: _site
 permalink: /:categories/:title/
 theme: linaro-jekyll-theme
@@ -97,7 +97,7 @@ http2_resources:
     href: /assets/fonts/lato/Lato-regular.woff2
 google_analytics:
   enabled: false
-  code: G-HMVFZEVJSK
+  code: GTM-XXXXXX
   cookies:
     necessary:
       - name: cookieControl
@@ -130,11 +130,11 @@ avatar_placeholder: /assets/images/avatar-placeholder.jpg
 post_placeholder: /assets/images/content/linaro-logo.png
 # Social Media Links
 social_media_channels:
-  github: false 
-  linkedin: false 
-  facebook: false 
-  youtube: false 
-  twitter: false 
+  github: false
+  linkedin: false
+  facebook: false
+  youtube: false
+  twitter: false
   instagram: false
 disqus:
   enabled: false


### PR DESCRIPTION
Adding Google Tag Manager with the new GA4 analytics property since the previous property is reaching end-of-life